### PR TITLE
Refactor ItemService addItems & addItemsToOperation to avoid redundan…

### DIFF
--- a/invoice/src/main/java/az/cybernet/invoice/dto/request/operation/AddItemsToOperationRequest.java
+++ b/invoice/src/main/java/az/cybernet/invoice/dto/request/operation/AddItemsToOperationRequest.java
@@ -1,0 +1,16 @@
+package az.cybernet.invoice.dto.request.operation;
+
+import az.cybernet.invoice.enums.OperationStatus;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class AddItemsToOperationRequest {
+    private Long invoiceId;
+    private String comment;
+    private OperationStatus status;
+    private List<Long> itemIds;
+}

--- a/invoice/src/main/java/az/cybernet/invoice/exception/ExceptionConstants.java
+++ b/invoice/src/main/java/az/cybernet/invoice/exception/ExceptionConstants.java
@@ -17,14 +17,15 @@ public enum ExceptionConstants {
     INVALID_STATUS("INVALID_STATUS", "Only PENDING invoices can be ..."),
     UNAUTHORIZED("UNAUTHORIZED", "You are not allowed to perform surgery"),
     HTTP_METHOD_IS_NOT_CORRECT("HTTP_METHOD_IS_NOT_CORRECT", "http method is not correct"),
-    RECIPIENT_NOT_FOUND("RECIPIENT_NOT_FOUND", "no recipient with id found");
+    RECIPIENT_NOT_FOUND("RECIPIENT_NOT_FOUND", "no recipient with id found"),
+    ITEM_NOT_FOUND("ITEM_NOT_FOUND","item not found");
 
     String code;
     String message;
 
     public String getMessage(Long id) {
         if ((this == SENDER_NOT_FOUND || this == RECIPIENT_NOT_FOUND
-                || this == INVOICE_NOT_FOUND) || this==MEASUREMENT_NOT_FOUND && id != null) {
+                || this == INVOICE_NOT_FOUND) || this==MEASUREMENT_NOT_FOUND && id != null || this==ITEM_NOT_FOUND) {
             return String.format("No %s with id (ID: %s) was found",
                     this.name().toLowerCase().replace("_not_found", ""), id);
         }

--- a/invoice/src/main/java/az/cybernet/invoice/service/abstraction/ItemService.java
+++ b/invoice/src/main/java/az/cybernet/invoice/service/abstraction/ItemService.java
@@ -2,12 +2,19 @@ package az.cybernet.invoice.service.abstraction;
 
 import az.cybernet.invoice.dto.request.item.ItemsRequest;
 import az.cybernet.invoice.dto.request.item.UpdateItemRequest;
+import az.cybernet.invoice.dto.request.operation.AddItemsToOperationRequest;
 import az.cybernet.invoice.dto.response.item.ItemResponse;
+import az.cybernet.invoice.enums.ItemStatus;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface ItemService {
     List<ItemResponse> addItems(ItemsRequest requests);
+
+    void addItemsToOperation(AddItemsToOperationRequest request);
+
+    void updateItemStatus(Long itemId, ItemStatus status);
 
     void updateItems(List<UpdateItemRequest> itemRequests);
 

--- a/invoice/src/main/java/az/cybernet/invoice/service/impl/ItemServiceImpl.java
+++ b/invoice/src/main/java/az/cybernet/invoice/service/impl/ItemServiceImpl.java
@@ -50,13 +50,13 @@ public class ItemServiceImpl implements ItemService {
 
         for (ItemRequest itemRequest : itemsRequest.getItemsRequest()) {
             MeasurementEntity measurement = measurementRepository.findByName(itemRequest.getMeasurementName());
+            itemRequest.setStatus(ItemStatus.CREATED);
             if (measurement == null) {
                 throw new IllegalArgumentException(
                         "Measurement with name '" + itemRequest.getMeasurementName() + "' not found"
                 );
             }
         }
-
 
         itemRepository.addItems(itemsRequest);
         List<ItemResponse> itemResponses = findAllItemsByInvoiceId(itemsRequest.getInvoiceId());
@@ -69,7 +69,7 @@ public class ItemServiceImpl implements ItemService {
                 AddItemsToOperationRequest.builder()
                         .invoiceId(itemsRequest.getInvoiceId())
                         .comment("Items added")
-                        .status(OperationStatus.UPDATE)
+                        .status(OperationStatus.DRAFT)
                         .itemIds(itemIds)
                         .build()
         );

--- a/invoice/src/main/resources/liquibase/1.0/20251001-create-items-table.yml
+++ b/invoice/src/main/resources/liquibase/1.0/20251001-create-items-table.yml
@@ -47,8 +47,8 @@ databaseChangeLog:
                     nullable: false
 
               - column:
-                  name: measurement_id
-                  type: BIGINT
+                  name: measurement_name
+                  type: VARCHAR(128)
                   constraints:
                     nullable: false
 
@@ -86,7 +86,7 @@ databaseChangeLog:
 
         - addForeignKeyConstraint:
             baseTableName: items
-            baseColumnNames: measurement_id
+            baseColumnNames: measurement_name
             referencedTableName: measurements
-            referencedColumnNames: id
+            referencedColumnNames: name
             constraintName: fk_items_measurement

--- a/invoice/src/main/resources/mappers/ItemMapper.xml
+++ b/invoice/src/main/resources/mappers/ItemMapper.xml
@@ -7,13 +7,15 @@
 
     <!-- INSERT -->
     <insert id="addItems">
-        INSERT INTO invoice_items (
+        INSERT INTO items (
         invoice_id,
         product_name,
         unit_price,
         quantity,
         total_price,
-        measurement_name
+        measurement_name,
+        is_active,
+        created_at
         )
         VALUES
         <foreach collection="itemsRequest.itemsRequest" item="item" separator=",">
@@ -23,7 +25,9 @@
             #{item.unitPrice},
             #{item.quantity},
             #{item.unitPrice} * #{item.quantity},
-            #{item.measurementName}
+            #{item.measurementName},
+            true,
+            NOW()
             )
         </foreach>
     </insert>

--- a/invoice/src/test/java/az/cybernet/invoice/service/ItemServiceTest.java
+++ b/invoice/src/test/java/az/cybernet/invoice/service/ItemServiceTest.java
@@ -121,14 +121,11 @@ class ItemServiceTest {
         itemRequest.setMeasurementName("kq"); // measurement name təyin edilir
         itemRequest.setUnitPrice(BigDecimal.valueOf(10));
         itemRequest.setQuantity(5);
+        itemRequest.setProductName("Alma");
         itemsRequest.setItemsRequest(List.of(itemRequest));
 
         MeasurementEntity measurementEntity = new MeasurementEntity();
         measurementEntity.setId(1L);
-
-        ItemEntity itemEntity = new ItemEntity();
-        itemEntity.setId(1L);
-        itemEntity.setName("Test Item");
 
 
         when(measurementRepository.findByName("kq")).thenReturn(measurementEntity);


### PR DESCRIPTION
Added itemIds field to AddItemsToOperationRequest to pass created item IDs directly .Modified addItems(...) to populate itemIds and prevent duplicate DB fetch.I fixed the error in Measurement liquibase