### PR TITLE
OTP generation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   invoice-db:
     image: postgres:16
@@ -37,6 +35,7 @@ services:
     container_name: user-management-service
     depends_on:
       - user-db
+      - redis
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://user-db:5432/${DB_NAME_USER}
       SPRING_DATASOURCE_USERNAME: ${DB_USERNAME_USER}
@@ -47,6 +46,12 @@ services:
       - "8081:8080"
     networks:
       - backend
+
+  redis:
+    image: redis:latest
+    container_name: redis-container
+    ports:
+      - "6379:6379"
 
   invoice-service:
     build:
@@ -75,3 +80,4 @@ networks:
 volumes:
   invoice-db-data:
   user-db-data:
+  redis-data:

--- a/integration/src/main/java/az/cybernet/integration/controller/SmsController.java
+++ b/integration/src/main/java/az/cybernet/integration/controller/SmsController.java
@@ -1,0 +1,25 @@
+package az.cybernet.integration.controller;
+
+import az.cybernet.integration.dto.OtpRequest;
+import az.cybernet.integration.service.SmsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.ResponseEntity.ok;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/sms")
+public class SmsController {
+
+    private final SmsService smsService;
+
+    @PostMapping("/send")
+    public ResponseEntity<String> sendSMS(@RequestBody OtpRequest request) {
+        return ok(smsService.sendOtp(request.getPhone(), request.getMessage()));
+    }
+}

--- a/integration/src/main/java/az/cybernet/integration/dto/OtpRequest.java
+++ b/integration/src/main/java/az/cybernet/integration/dto/OtpRequest.java
@@ -1,0 +1,17 @@
+package az.cybernet.integration.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class OtpRequest {
+    @NotBlank
+    String phone;
+    @NotBlank
+    String message;
+}

--- a/integration/src/main/java/az/cybernet/integration/service/SmsService.java
+++ b/integration/src/main/java/az/cybernet/integration/service/SmsService.java
@@ -1,0 +1,14 @@
+package az.cybernet.integration.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SmsService {
+
+    public String sendOtp(String phone, String message) {
+        return String.format("Sent SMS message with content \"%s\" to  %s", phone, message);
+    }
+
+}

--- a/user-management/pom.xml
+++ b/user-management/pom.xml
@@ -25,14 +25,24 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.19.0</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
     </dependencies>
-
 
     <build>
         <plugins>

--- a/user-management/src/main/java/az/cybernet/usermanagement/UserManagement.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/UserManagement.java
@@ -3,9 +3,15 @@ package az.cybernet.usermanagement;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @MapperScan("az.cybernet.usermanagement.repository")
+@EnableCaching
+@EnableFeignClients(basePackages = "az.cybernet.usermanagement.client")
+@EnableConfigurationProperties
 public class UserManagement {
     public static void main(String[] args) {
         SpringApplication.run(UserManagement.class, args);

--- a/user-management/src/main/java/az/cybernet/usermanagement/client/IntegrationClient.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/client/IntegrationClient.java
@@ -1,0 +1,12 @@
+package az.cybernet.usermanagement.client;
+
+import az.cybernet.usermanagement.dto.request.OtpRequest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "integration", url = "http://localhost:8081")
+public interface IntegrationClient {
+    @PostMapping("/api/integration/v1/sms/send")
+    String sendOtp(@RequestBody OtpRequest request);
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/config/RedisConfig.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package az.cybernet.usermanagement.config;
+
+import az.cybernet.usermanagement.entity.Otp;
+import az.cybernet.usermanagement.entity.RecentLoginAttempts;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, RecentLoginAttempts> getLoginAttemsRedisTemplate(RedisConnectionFactory redisConnectionFactory){
+        RedisTemplate<String,RecentLoginAttempts> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, Otp> getOtpRedisTemplate(RedisConnectionFactory redisConnectionFactory){
+        RedisTemplate<String, Otp> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        return redisTemplate;
+    }
+
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/controller/LoginController.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/controller/LoginController.java
@@ -1,0 +1,39 @@
+package az.cybernet.usermanagement.controller;
+
+import az.cybernet.usermanagement.dto.request.EnterCodeByTelegramRequest;
+import az.cybernet.usermanagement.dto.request.LoginByEmailRequest;
+import az.cybernet.usermanagement.dto.request.LoginByTelegramRequest;
+import az.cybernet.usermanagement.dto.request.LoginRequest;
+import az.cybernet.usermanagement.service.abstraction.LoginService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class LoginController {
+
+    private final LoginService loginService;
+
+    @PostMapping("/login-by-phone")
+    public String loginByPhone(@RequestBody @Valid LoginRequest loginRequest) {
+        return loginService.loginByPhone(loginRequest);
+    }
+
+    @PostMapping("/login-by-email")
+    public String loginByEmail(@RequestBody @Valid LoginByEmailRequest loginByEmailRequest) {
+        return loginService.loginByEmail(loginByEmailRequest);
+    }
+
+    @PostMapping("/login-by-telegram-bot")
+    public String loginByTelegram(@RequestBody @Valid LoginByTelegramRequest request) {
+        return loginService.loginByTelegram(request);
+    }
+
+    @PostMapping("/verify-otp-code")
+    public boolean verify(@RequestBody EnterCodeByTelegramRequest request) {
+        return loginService.checkIsVerificationCodeSuccess(request);
+    }
+}
+

--- a/user-management/src/main/java/az/cybernet/usermanagement/dto/request/EnterCodeByTelegramRequest.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/dto/request/EnterCodeByTelegramRequest.java
@@ -1,0 +1,26 @@
+package az.cybernet.usermanagement.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EnterCodeByTelegramRequest {
+    @NotBlank
+    @Size(min = 7, max = 7, message = "PIN must be exactly 7 characters")
+    private String pin;
+
+    @Pattern(regexp = "\\+994?(10|50|51|55|60|70|77|99)[0-9]{7}", message = "INVALID_PHONE_NUMBER")
+    private String phoneNumber;
+    private String chatId;
+    @NotNull
+    private String code;
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/dto/request/LoginByEmailRequest.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/dto/request/LoginByEmailRequest.java
@@ -1,0 +1,22 @@
+package az.cybernet.usermanagement.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginByEmailRequest {
+    @NotBlank
+    @Size(min = 7, max = 7, message = "PIN must be exactly 7 characters")
+    private String pin;
+
+    @NotNull
+    private String email;
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/dto/request/LoginByTelegramRequest.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/dto/request/LoginByTelegramRequest.java
@@ -1,0 +1,23 @@
+package az.cybernet.usermanagement.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginByTelegramRequest {
+    @NotBlank
+    @Size(min = 7, max = 7, message = "PIN must be exactly 7 characters")
+    private String pin;
+
+    @Pattern(regexp = "\\+994?(10|50|51|55|60|70|77|99)[0-9]{7}", message = "INVALID_PHONE_NUMBER")
+    private String phoneNumber;
+    private String chatId;
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/dto/request/LoginRequest.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/dto/request/LoginRequest.java
@@ -1,0 +1,23 @@
+package az.cybernet.usermanagement.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequest {
+    @NotBlank
+    @Size(min = 7, max = 7, message = "PIN must be exactly 7 characters")
+    private String pin;
+
+    @Pattern(regexp = "\\+994?(10|50|51|55|60|70|77|99)[0-9]{7}", message = "INVALID_PHONE_NUMBER")
+    private String phoneNumber;
+}
+

--- a/user-management/src/main/java/az/cybernet/usermanagement/dto/request/OtpRequest.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/dto/request/OtpRequest.java
@@ -1,0 +1,17 @@
+package az.cybernet.usermanagement.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class OtpRequest {
+    @NotBlank
+    String phone;
+    @NotBlank
+    String message;
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/entity/FinLoginData.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/entity/FinLoginData.java
@@ -1,0 +1,21 @@
+package az.cybernet.usermanagement.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FinLoginData {
+
+    private Long id;
+    private String insertDate;
+    private String pin;
+    private String phoneNumber;
+    private boolean state;
+    private String verificationCode;
+    private Integer numberOfAttempts;
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/entity/LoginAttempt.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/entity/LoginAttempt.java
@@ -1,0 +1,14 @@
+package az.cybernet.usermanagement.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LoginAttempt {
+    private String date;
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/entity/Otp.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/entity/Otp.java
@@ -1,0 +1,13 @@
+package az.cybernet.usermanagement.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Otp {
+    private String verificationCode;
+    private int attemptCount;
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/entity/RecentLoginAttempts.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/entity/RecentLoginAttempts.java
@@ -1,0 +1,14 @@
+package az.cybernet.usermanagement.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecentLoginAttempts {
+    private List<LoginAttempt> loginAttempts ;
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/exception/OtpLimitExceededException.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/exception/OtpLimitExceededException.java
@@ -1,0 +1,8 @@
+package az.cybernet.usermanagement.exception;
+
+public class OtpLimitExceededException extends RuntimeException {
+    public OtpLimitExceededException(String message) {
+        super(message);
+    }
+}
+

--- a/user-management/src/main/java/az/cybernet/usermanagement/exception/RedisOperationException.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/exception/RedisOperationException.java
@@ -1,0 +1,12 @@
+package az.cybernet.usermanagement.exception;
+
+public class RedisOperationException extends RuntimeException {
+
+    public RedisOperationException(String message) {
+        super(message);
+    }
+
+    public RedisOperationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/exception/VerificationCodeException.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/exception/VerificationCodeException.java
@@ -1,0 +1,14 @@
+package az.cybernet.usermanagement.exception;
+
+import lombok.Getter;
+
+@Getter
+public class VerificationCodeException extends RuntimeException {
+    private final int httpStatus;
+
+    public VerificationCodeException(String message, int httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/repository/OtpRepository.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/repository/OtpRepository.java
@@ -1,0 +1,10 @@
+package az.cybernet.usermanagement.repository;
+
+import az.cybernet.usermanagement.entity.FinLoginData;
+import org.apache.ibatis.annotations.Param;
+
+public interface OtpRepository {
+    void insertOTPLoginData(@Param("loginData") FinLoginData loginData);
+
+    void updateLoginOTPData(@Param("code") String code, @Param("pin") String pin, @Param("phoneNumber") String phoneNumber);
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/service/abstraction/IntegrationService.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/service/abstraction/IntegrationService.java
@@ -1,0 +1,5 @@
+package az.cybernet.usermanagement.service.abstraction;
+
+public interface IntegrationService {
+    void sendOtp(String phone, String otp);
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/service/abstraction/LoginService.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/service/abstraction/LoginService.java
@@ -1,0 +1,16 @@
+package az.cybernet.usermanagement.service.abstraction;
+
+import az.cybernet.usermanagement.dto.request.EnterCodeByTelegramRequest;
+import az.cybernet.usermanagement.dto.request.LoginByEmailRequest;
+import az.cybernet.usermanagement.dto.request.LoginByTelegramRequest;
+import az.cybernet.usermanagement.dto.request.LoginRequest;
+
+public interface LoginService {
+    String loginByPhone(LoginRequest loginRequest);
+
+    String loginByEmail(LoginByEmailRequest loginByEmailRequest);
+
+    String loginByTelegram(LoginByTelegramRequest loginByTelegramRequest);
+
+    boolean checkIsVerificationCodeSuccess(EnterCodeByTelegramRequest request);
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/service/impl/IntegrationServiceImpl.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/service/impl/IntegrationServiceImpl.java
@@ -1,0 +1,22 @@
+package az.cybernet.usermanagement.service.impl;
+
+import az.cybernet.usermanagement.client.IntegrationClient;
+import az.cybernet.usermanagement.dto.request.OtpRequest;
+import az.cybernet.usermanagement.service.abstraction.IntegrationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class IntegrationServiceImpl implements IntegrationService {
+
+    private final IntegrationClient integrationClient;
+
+    @Override
+    public void sendOtp(String phone, String message) {
+        Optional.ofNullable(integrationClient.sendOtp(new OtpRequest(phone, message)))
+                .orElseThrow();
+    }
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/service/impl/LoginHelper.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/service/impl/LoginHelper.java
@@ -1,0 +1,38 @@
+package az.cybernet.usermanagement.service.impl;
+
+import az.cybernet.usermanagement.dto.request.LoginByTelegramRequest;
+import az.cybernet.usermanagement.entity.FinLoginData;
+import az.cybernet.usermanagement.repository.OtpRepository;
+import az.cybernet.usermanagement.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class LoginHelper {
+
+    private  final OtpRepository otpRepository;
+
+    public void insertOTPLoginData(LoginByTelegramRequest request, String verificationCode) {
+        FinLoginData loginData = FinLoginData.builder()
+                .pin(request.getPin())
+                .phoneNumber(request.getPhoneNumber())
+                .verificationCode(verificationCode)
+                .numberOfAttempts(0)
+                .insertDate(
+                        LocalDateTime.now()
+                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+                )
+                .state(false)
+                .build();
+
+        otpRepository.insertOTPLoginData(loginData);
+    }
+
+    public void updateLoginOTPData(String code, String pin, String phoneNumber) {
+        otpRepository.updateLoginOTPData(code, pin, phoneNumber);
+    }
+}

--- a/user-management/src/main/java/az/cybernet/usermanagement/service/impl/LoginServiceImpl.java
+++ b/user-management/src/main/java/az/cybernet/usermanagement/service/impl/LoginServiceImpl.java
@@ -1,0 +1,188 @@
+package az.cybernet.usermanagement.service.impl;
+
+import az.cybernet.usermanagement.dto.request.EnterCodeByTelegramRequest;
+import az.cybernet.usermanagement.dto.request.LoginByEmailRequest;
+import az.cybernet.usermanagement.dto.request.LoginByTelegramRequest;
+import az.cybernet.usermanagement.dto.request.LoginRequest;
+import az.cybernet.usermanagement.entity.LoginAttempt;
+import az.cybernet.usermanagement.entity.Otp;
+import az.cybernet.usermanagement.entity.RecentLoginAttempts;
+import az.cybernet.usermanagement.exception.OtpLimitExceededException;
+import az.cybernet.usermanagement.exception.RedisOperationException;
+import az.cybernet.usermanagement.exception.VerificationCodeException;
+import az.cybernet.usermanagement.service.abstraction.IntegrationService;
+import az.cybernet.usermanagement.service.abstraction.LoginService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LoginServiceImpl implements LoginService {
+    private final IntegrationService integrationService;
+    private final StringRedisTemplate redisTemplate;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final RedisTemplate<String, RecentLoginAttempts> attemptsRedisTemplate;
+    private final RedisTemplate<String, Otp> otpRedisTemplate;
+    private final LoginHelper loginHelper;
+    private final JavaMailSender mailSender;
+
+    @Value("${telegram.bot.token}")
+    private String botToken;
+
+    @Override
+    public String loginByPhone(LoginRequest loginRequest) {
+        String phoneNumber = loginRequest.getPhoneNumber();
+        //todo pin və phoneNumber must check
+        String otp = String.valueOf(this.generateOtp());
+        redisTemplate.opsForValue().set("OTP_" + phoneNumber, otp, 5, TimeUnit.MINUTES);
+        integrationService.sendOtp(phoneNumber, otp);
+        return "OTP sent: " + phoneNumber;
+    }
+
+    @Override
+    public String loginByEmail(LoginByEmailRequest loginByEmailRequest) {
+        String email = loginByEmailRequest.getEmail();
+        String otp = String.valueOf(this.generateOtp());
+        redisTemplate.opsForValue().set("OTP_" + email, otp, 5, TimeUnit.MINUTES);
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("Sizin OTP kodunuz");
+        message.setText("Sizin OTP kodunuz: " + otp);
+        mailSender.send(message);
+        return "OTP sent: " + email;
+    }
+
+    public int generateOtp() {
+        SecureRandom random = new SecureRandom();
+        return 100000 + random.nextInt(900000);
+    }
+
+    @Override
+    public String loginByTelegram(LoginByTelegramRequest request) {
+        checkAttemptsLimit(request);
+        String verificationCode = generateOtpAndSaveAtRedis(request);
+
+        try {
+            String url = "https://api.telegram.org/bot" + botToken + "/sendMessage";
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("chat_id", request.getChatId());
+            params.add("text", verificationCode);
+
+            restTemplate.postForObject(url, params, String.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "An error occurred: " + e.getMessage();
+        }
+
+        loginHelper.insertOTPLoginData(request, verificationCode);
+        return "OTP sent";
+    }
+
+    private void checkAttemptsLimit(LoginByTelegramRequest request) {
+        LocalDateTime oneHourAgo = LocalDateTime.now().minusHours(1);
+        String loginByFinCacheKey = getLoginByFinCacheKey(request.getPin());
+
+        if (hasKeyInRedis(loginByFinCacheKey)) {
+            RecentLoginAttempts recentLoginAttempts = attemptsRedisTemplate.opsForValue().get(loginByFinCacheKey);
+
+            if (Objects.isNull(recentLoginAttempts)) {
+                log.warn("Recent login attempts is null for request {}", request);
+                recentLoginAttempts = new RecentLoginAttempts(new ArrayList<>());
+            }
+
+            recentLoginAttempts.getLoginAttempts().removeIf(attempt -> LocalDateTime
+                    .parse(attempt.getDate()).isBefore(oneHourAgo));
+
+            if (recentLoginAttempts.getLoginAttempts().size() > 2) {
+                log.error("User trying to send too many otp {}", request);
+                throw new OtpLimitExceededException("Too many OTP requests in 1 hour");
+            }
+        }
+    }
+
+    private String generateOtpAndSaveAtRedis(LoginByTelegramRequest request) {
+        Otp otp = new Otp(String.valueOf(generateOtp()), 0);
+        String loginByFinCacheKey = getLoginByFinCacheKey(request.getPin());
+
+        RecentLoginAttempts recentLoginAttempts = new RecentLoginAttempts(new ArrayList<>());
+        otpRedisTemplate.opsForValue().set(getOtpCodeCacheKey(request.getPin()), otp, 5, TimeUnit.MINUTES);
+
+        if (hasKeyInRedis(loginByFinCacheKey)) {
+            recentLoginAttempts = attemptsRedisTemplate.opsForValue().get(loginByFinCacheKey);
+        }
+
+        if (Objects.isNull(recentLoginAttempts) || Objects.isNull(recentLoginAttempts.getLoginAttempts())) {
+            throw new RedisOperationException("Failed to retrieve login attempts data from Redis");
+        }
+
+        recentLoginAttempts.getLoginAttempts().add(new LoginAttempt(LocalDateTime.now().toString()));
+
+        attemptsRedisTemplate.opsForValue().set(loginByFinCacheKey, recentLoginAttempts, 5, TimeUnit.MINUTES);
+
+        return otp.getVerificationCode();
+    }
+
+    private String getLoginByFinCacheKey(String pin) {
+        return "loginByFinCacheKey-" + pin;
+    }
+
+    private String getOtpCodeCacheKey(String fin) {
+        return "otpCodeCacheKey-" + fin;
+    }
+
+    public boolean hasKeyInRedis(String key) {
+        try {
+            return attemptsRedisTemplate.hasKey(key);
+        } catch (Exception e) {
+            log.error("Redis error while checking key {}: {}", key, e.getMessage(), e);
+            throw new RedisOperationException("Redis error while checking key: " + key, e);
+        }
+    }
+
+    @Override
+    public boolean checkIsVerificationCodeSuccess(EnterCodeByTelegramRequest request) {
+        log.info("Enter code request {} ", request);
+        String otpCacheKey = getOtpCodeCacheKey(request.getPin());
+
+        if (hasKeyInRedis(otpCacheKey)) {
+            Otp otp = otpRedisTemplate.opsForValue().get(otpCacheKey);
+
+            if (Objects.isNull(otp)) {
+                log.error("Otp code not found at redis");
+                throw new VerificationCodeException("OTP expired or not found", 400);
+            }
+            if (otp.getAttemptCount() > 2) {
+                log.error("User has entered the OTP code incorrectly more than 3 times");
+                throw new VerificationCodeException("OTP attempt limit reached", 400);
+            }
+            if (!otp.getVerificationCode().equals(request.getCode())) {
+                otp.setAttemptCount(otp.getAttemptCount() + 1);
+                otpRedisTemplate.opsForValue().set(otpCacheKey, otp, 1, TimeUnit.HOURS);
+                log.error("User has entered the OTP code incorrect");
+                throw new VerificationCodeException("Wrong OTP code", 400);
+            }
+        } else {
+            log.error("OTP not found in Redis, possibly expired");
+            throw new VerificationCodeException("OTP expired or not found", 400);
+        }
+       // loginHelper.updateLoginOTPData(request.getCode(), request.getPin(), request.getPhoneNumber());
+        return true;
+    }
+}

--- a/user-management/src/main/resources/application.yml
+++ b/user-management/src/main/resources/application.yml
@@ -10,9 +10,29 @@ spring:
     liquibase-schema: public
     drop-first: true
 
-mybatis:
-  mapper-locations: classpath:mapper/*.xml
-  configuration:
-    map-underscore-to-camel-case: true
-    default-fetch-size: 100
-    default-statement-timeout: 30
+
+  cache:
+    type: redis
+    host: localhost
+    port: 6379
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+    mapper-locations: classpath:mapper/*.xml
+    configuration:
+      map-underscore-to-camel-case: true
+      default-fetch-size: 100
+      default-statement-timeout: 30
+
+  telegram:
+    bot:
+      token: ${TELEGRAM_BOT_TOKEN}

--- a/user-management/src/main/resources/liquibase/1.0/20251002-create-otp-login-data-table.yml
+++ b/user-management/src/main/resources/liquibase/1.0/20251002-create-otp-login-data-table.yml
@@ -1,0 +1,50 @@
+databaseChangeLog:
+  - changeSet:
+      id: 20251002
+      author: gulnare
+      changes:
+        - createTable:
+            schemaName: users
+            tableName: otp_login_data
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+                    primaryKeyName: otp_login_data_primary_key
+              - column:
+                  name: pin
+                  type: VARCHAR(7)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: phone_number
+                  type: VARCHAR(12)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: verification_code
+                  type: VARCHAR(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: number_of_attempts
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: insert_date
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: state
+                  type: VARCHAR(30)
+                  defaultValue: "0"
+                  constraints:
+                    nullable: false

--- a/user-management/src/main/resources/liquibase/changelog-master.yml
+++ b/user-management/src/main/resources/liquibase/changelog-master.yml
@@ -4,3 +4,7 @@ databaseChangeLog:
 
   - include:
       file: liquibase/1.0/20251000-create-users-table.yml
+
+
+  - include:
+      file: liquibase/1.0/20251002-create-otp-login-data-table.yml

--- a/user-management/src/main/resources/mapper/OtpMapper.xml
+++ b/user-management/src/main/resources/mapper/OtpMapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="az.cybernet.usermanagement.repository.OtpRepository">
+
+    <resultMap id="UserResultMap" type="az.cybernet.usermanagement.entity.UserEntity">
+        <id property="id" column="id"/>
+        <result property="name" column="name"/>
+        <result property="taxId" column="tax_id"/>
+        <result property="isActive" column="is_active"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+    <insert id="insertOTPLoginData" parameterType="az.cybernet.usermanagement.entity.FinLoginData">
+        INSERT INTO users.otp_login_data (pin, phone_number, verification_code, number_of_attempts, insert_date, state)
+        VALUES (#{loginData.pin}, #{loginData.phoneNumber}, #{loginData.verificationCode},
+                #{loginData.numberOfAttempts},
+                #{loginData.insertDate}, #{loginData.state})
+    </insert>
+    <update id="updateLoginOTPData">
+        update users.otp_login_data
+        set state = true
+        where verification_code = #{code}
+          and pin = #{pin}
+          and phone_number = #{phoneNumber};
+    </update>
+
+</mapper>


### PR DESCRIPTION
User Login OTP Project: This project provides secure user login using FIN and phone number. Upon login, a 6-digit OTP is generated, hashed, and stored in the database, remaining valid for 5 minutes. Incorrect attempts are allowed twice, and the third attempt blocks the OTP. The OTP can be sent via a Mock API, Telegram, or Gmail or phone. When the user enters the correct OTP, is_active=true is set. A scheduler automatically deletes the OTP after 5 minutes. The project is built with MyBatis, PostgreSQL, and Liquibase, and includes a /verify-otp endpoint for OTP verification